### PR TITLE
Dynamic number of disco nodes on a single instance

### DIFF
--- a/anaconda_plugin.py
+++ b/anaconda_plugin.py
@@ -24,10 +24,10 @@ class ConfigAnaconda(ClusterSetup):
         Create a disco config file that includes all the nodes and restart disco.
         """
         remote_nodes = filter(lambda n: not n.is_master(), nodes)
-        names = map(lambda n: n.alias, remote_nodes)
-        recs = map(lambda x: ',\n["%s", "1"]' % x, names)
+        #names = map(lambda n: n.alias, remote_nodes)
+        recs = map(lambda n: ',\n["%s", "%d"]' % (n.alias, n.num_processors), remote_nodes)
         body = reduce(lambda x, y: x + y, recs, '')
-        dconfig = '[["master", "1"]' + body + ']'
+        dconfig = '[["master", "%d"]' % (master.num_processors,) + body + ']'
 
         cfd = master.ssh.remote_file(DISCO_CONFIG)
         cfd.write(dconfig)
@@ -42,8 +42,8 @@ class ConfigAnaconda(ClusterSetup):
             """
             remote_nodes = filter(lambda n: not n.is_master(), nodes)
             names = map(lambda n: n.alias, remote_nodes)
-            recs = map(lambda x: ',\n["%s", "1"]' % x, names)
-            body = reduce(lambda x, y: x + y, recs, '')
+            #recs = map(lambda n: ',\n["%s", "%d"]' % (n.alias, n.num_processors), remote_nodes)
+            #body = reduce(lambda x, y: x + y, recs, '')
             #master.ssh.execute("sudo su - disco;")
             master.ssh.execute("/etc/init.d/disco stop")
             


### PR DESCRIPTION
... single machine (node in the cluster) based upon the number of processors observed on that machine (e.g. c1.medium would have 2 virtual cores and so an assignment of 2 disco nodes for that c1.medium instance is made).

Hi Ben -- I've tested this in two different configurations:  a cluster of 2 instances of c1.medium (each instance gets 2 disco nodes for a total of 4), and a cluster of 2 instances of m1.small (each instance gets 1 disco node for a total of 2).  I can provide more background on what I actually did to play with it in testing.  Hope this helps,  Davin
